### PR TITLE
Allow to group extended PTZ commands in sub menues.

### DIFF
--- a/AddCamera.cs
+++ b/AddCamera.cs
@@ -1513,9 +1513,22 @@ namespace iSpyApplication
                 CameraControl.PTZ.PTZSettings = ptz;
                 if (ptz.ExtendedCommands?.Command != null)
                 {
+                    string subMenu = "";
                     foreach (var extcmd in ptz.ExtendedCommands.Command)
                     {
-                        lbExtended.Items.Add(new ListItem(extcmd.Name, extcmd.Value));
+                        if ((extcmd.Value ?? "") != "")
+                        {
+                            lbExtended.Items.Add(new ListItem(subMenu + extcmd.Name, extcmd.Value));
+                        }
+                        else if ((extcmd.Name ?? MainForm.PTZ_SUBMENU_END) != MainForm.PTZ_SUBMENU_END)
+                        {
+                            lbExtended.Items.Add(new ListItem(subMenu + extcmd.Name, extcmd.Value));
+                            subMenu = subMenu + "\t";   // PTZ_SUBMENU_START;
+                        }
+                        else
+                        {
+                            subMenu = subMenu.Substring(1);
+                        }
                     }
                 }
                 if (_loaded)

--- a/MainForm_Configuration.cs
+++ b/MainForm_Configuration.cs
@@ -42,6 +42,8 @@ namespace iSpyApplication
         private static List<objectsCommand> _remotecommands;
         private static List<objectsCamera> _cameras;
 
+        public static string PTZ_SUBMENU_END = "..";
+
         public static void ReloadColors()
         {
             _backColor =
@@ -3515,16 +3517,30 @@ namespace iSpyApplication
                             PTZSettings2Camera ptz = PTZs.SingleOrDefault(p => p.id == cameraControl.Camobject.ptz);
                             if (ptz?.ExtendedCommands?.Command != null)
                             {
+                                var subMenus = new List<ToolStripItemCollection>() {
+                                    pTZToolStripMenuItem.DropDownItems
+                                };
+
                                 foreach (var extcmd in ptz.ExtendedCommands.Command)
                                 {
-                                    ToolStripItem tsi = new ToolStripMenuItem
+                                    ToolStripMenuItem tsi = new ToolStripMenuItem
                                                         {
                                                             Text = extcmd.Name,
                                                             Tag =
                                                                 cameraControl.Camobject.id + "|" + extcmd.Value
                                                         };
-                                    tsi.Click += TsiClick;
-                                    pTZToolStripMenuItem.DropDownItems.Add(tsi);
+                                    if ((extcmd.Value ?? "") != "")
+                                    {
+                                        tsi.Click += TsiClick;
+                                        subMenus[0].Add(tsi);
+                                    }
+                                    else if ((extcmd.Name ?? PTZ_SUBMENU_END) != PTZ_SUBMENU_END)
+                                    {
+                                        subMenus[0].Add(tsi);
+                                        subMenus.Insert(0, tsi.DropDownItems);  // PTZ_SUBMENU_START
+                                    }
+                                    else if (subMenus.Count > 1)
+                                        subMenus.RemoveAt(0);
                                 }
                             }
                         }

--- a/XML/PTZ2.xml
+++ b/XML/PTZ2.xml
@@ -767,6 +767,7 @@
       <ZoomOut>command=16</ZoomOut>
     </Commands>
     <ExtendedCommands>
+      <Command Name="Call" />
       <Command Name="GO Preset 1">command=31</Command>
       <Command Name="GO Preset 2">command=33</Command>
       <Command Name="GO Preset 3">command=35</Command>
@@ -775,6 +776,8 @@
       <Command Name="GO Preset 6">command=41</Command>
       <Command Name="GO Preset 7">command=43</Command>
       <Command Name="GO Preset 8">command=45</Command>
+      <Command Name=".." />
+      <Command Name="Save" />
       <Command Name="Set Preset 1">command=30</Command>
       <Command Name="Set Preset 2">command=32</Command>
       <Command Name="Set Preset 3">command=34</Command>
@@ -783,9 +786,12 @@
       <Command Name="Set Preset 6">command=40</Command>
       <Command Name="Set Preset 7">command=42</Command>
       <Command Name="Set Preset 8">command=44</Command>
+      <Command Name=".." />
+      <Command Name="Patrol" />
       <Command Name="Stop">command=1</Command>
       <Command Name="Start H Patrol">command=20</Command>
       <Command Name="Stop H Patrol">command=21</Command>
+      <Command Name=".." />
       <Command Name="Switch ON">command=94</Command>
       <Command Name="Switch OFF">command=95</Command>
     </ExtendedCommands>


### PR DESCRIPTION
An example of how to define groups is in PTZ2.xml at
camera <Make Name="Wanscam" Model="AJ-C0WA-C0D8" />.