### PR TITLE
Implement 'keepEdges' option for all frame difference detectors

### DIFF
--- a/Controls/CameraWindow.cs
+++ b/Controls/CameraWindow.cs
@@ -5377,7 +5377,7 @@ namespace iSpyApplication.Controls
                 case "Two Frames":
                     Camera.MotionDetector =
                         new MotionDetector(
-                            new TwoFramesDifferenceDetector(Camobject.settings.suppressnoise));
+                            new TwoFramesDifferenceDetector(Camobject.settings.suppressnoise,Camobject.detector.keepobjectedges));
                     SetProcessor();
                     break;
                 case "Custom Frame":
@@ -5395,7 +5395,7 @@ namespace iSpyApplication.Controls
                 case "Two Frames (Color)":
                     Camera.MotionDetector =
                         new MotionDetector(
-                            new TwoFramesColorDifferenceDetector(Camobject.settings.suppressnoise));
+                            new TwoFramesColorDifferenceDetector(Camobject.settings.suppressnoise,Camobject.detector.keepobjectedges));
                     SetProcessor();
                     break;
                 case "Custom Frame (Color)":

--- a/Vision/CustomFrameColorDifferenceDetector.cs
+++ b/Vision/CustomFrameColorDifferenceDetector.cs
@@ -336,13 +336,15 @@ namespace iSpyApplication.Vision
                 if ( _suppressNoise )
                 {
                     // suppress noise and calculate motion amount
-                    AForge.SystemTools.CopyUnmanagedMemory( _tempFrame.ImageData, _motionFrame.ImageData, _motionSize );
-                    _erosionFilter.Apply( _tempFrame, _motionFrame );
+                    _erosionFilter.Apply( _motionFrame, _tempFrame );    // src -> dst
 
                     if ( _keepObjectEdges )
                     {
-                        AForge.SystemTools.CopyUnmanagedMemory( _tempFrame.ImageData, _motionFrame.ImageData, _motionSize );
-                        _dilatationFilter.Apply( _tempFrame, _motionFrame );
+                        _dilatationFilter.Apply( _tempFrame, _motionFrame );  // src -> dst
+                    }
+                    else
+                    {
+                        AForge.SystemTools.CopyUnmanagedMemory( _motionFrame.ImageData, _tempFrame.ImageData, _motionSize );  // dst <- src
                     }
                 }
 

--- a/Vision/CustomFrameDifferenceDetector.cs
+++ b/Vision/CustomFrameDifferenceDetector.cs
@@ -77,7 +77,7 @@ namespace iSpyApplication.Vision
 
         // suppress noise
         private bool _suppressNoise   = true;
-        private bool _keepObjectEdges;
+        private bool _keepObjectEdges = false;
 
         // threshold values
         private int _differenceThreshold    =  15;
@@ -324,13 +324,15 @@ namespace iSpyApplication.Vision
                 if ( _suppressNoise )
                 {
                     // suppress noise and calculate motion amount
-                    AForge.SystemTools.CopyUnmanagedMemory( _tempFrame.ImageData, _motionFrame.ImageData, _frameSize );
-                    _erosionFilter.Apply( _tempFrame, _motionFrame );
+                    _erosionFilter.Apply( _motionFrame, _tempFrame );    // src -> dst
 
                     if ( _keepObjectEdges )
                     {
-                        AForge.SystemTools.CopyUnmanagedMemory( _tempFrame.ImageData, _motionFrame.ImageData, _frameSize );
-                        _dilatationFilter.Apply( _tempFrame, _motionFrame );
+                        _dilatationFilter.Apply( _tempFrame, _motionFrame );  // src -> dst
+                    }
+                    else
+                    {
+                        AForge.SystemTools.CopyUnmanagedMemory( _motionFrame.ImageData, _tempFrame.ImageData, _frameSize );  // dst <- src
                     }
                 }
 

--- a/Vision/TwoFramesDifferenceDetector.cs
+++ b/Vision/TwoFramesDifferenceDetector.cs
@@ -66,6 +66,7 @@ namespace iSpyApplication.Vision
 
         // suppress noise
         private bool _suppressNoise = true;
+        private bool _keepObjectEdges = false;
 
         // threshold values
         private int _differenceThreshold    =  15;
@@ -73,6 +74,8 @@ namespace iSpyApplication.Vision
 
         // binary erosion filter
         private readonly BinaryErosion3x3 _erosionFilter = new BinaryErosion3x3( );
+        // binary dilatation filter
+        private readonly BinaryDilatation3x3 _dilatationFilter = new BinaryDilatation3x3();
 
         // dummy object to lock for synchronization
         private readonly object _sync = new object( );
@@ -182,6 +185,31 @@ namespace iSpyApplication.Vision
         }
 
         /// <summary>
+        /// Restore objects edges after noise suppression or not.
+        /// </summary>
+        /// 
+        /// <remarks><para>The value specifies if additional filtering should be done
+        /// to restore objects' edges after noise suppression by applying 3x3 dilatation
+        /// image processing filter.</para>
+        /// 
+        /// <para>Default value is set to <see langword="false"/>.</para>
+        /// 
+        /// <para><note>Turning the value on leads to more processing time of video frame.</note></para>
+        /// </remarks>
+        /// 
+        public bool KeepObjectsEdges
+        {
+            get { return _keepObjectEdges; }
+            set
+            {
+                lock (_sync)
+                {
+                    _keepObjectEdges = value;
+                }
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TwoFramesDifferenceDetector"/> class.
         /// </summary>
         /// 
@@ -196,6 +224,20 @@ namespace iSpyApplication.Vision
         public TwoFramesDifferenceDetector( bool suppressNoise )
         {
             _suppressNoise = suppressNoise;
+            _keepObjectEdges = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TwoFramesDifferenceDetector"/> class.
+        /// </summary>
+        /// 
+        /// <param name="suppressNoise">Suppress noise in video frames or not (see <see cref="SuppressNoise"/> property).</param>
+        /// <param name="keepObjectEdges">Restore objects edges after noise suppression or not (see <see cref="KeepObjectsEdges"/> property).</param>
+        /// 
+        public TwoFramesDifferenceDetector( bool suppressNoise, bool keepObjectEdges )
+        {
+            _suppressNoise = suppressNoise;
+            _keepObjectEdges = keepObjectEdges;
         }
 
         /// <summary>
@@ -267,8 +309,16 @@ namespace iSpyApplication.Vision
                 if ( _suppressNoise )
                 {
                     // suppress noise and calculate motion amount
-                    AForge.SystemTools.CopyUnmanagedMemory( _tempFrame.ImageData, _motionFrame.ImageData, _frameSize );
-                    _erosionFilter.Apply( _tempFrame, _motionFrame );
+                    _erosionFilter.Apply( _motionFrame, _tempFrame );    // src -> dst
+
+                    if ( _keepObjectEdges )
+                    {
+                        _dilatationFilter.Apply( _tempFrame, _motionFrame );  // src -> dst
+                    }
+                    else
+                    {
+                        AForge.SystemTools.CopyUnmanagedMemory( _motionFrame.ImageData, _tempFrame.ImageData, _frameSize );  // dst <- src
+                    }
                 }
 
                 // calculate amount of motion pixels


### PR DESCRIPTION
BTW prevent two frame buffer copies if keepEdges is enabled.