### PR TITLE
speedup in frame reading and recording threads.  Fixed build break

### DIFF
--- a/Controls/CameraWindow.cs
+++ b/Controls/CameraWindow.cs
@@ -50,7 +50,7 @@ namespace iSpyApplication.Controls
         private Color _customColor = Color.Black;
         private DateTime _lastRedraw = DateTime.MinValue;
         private DateTime _recordingStartTime;
-        private readonly ManualResetEvent _stopWrite = new ManualResetEvent(false);
+        private bool _stopWrite = false;
         private readonly ManualResetEvent _writerStopped = new ManualResetEvent(false); 
         private double _autoofftimer;
         private bool _raiseStop;
@@ -3098,7 +3098,7 @@ namespace iSpyApplication.Controls
                 AbortedAudio = false;
                 LogToPlugin("Recording Started");
                 string linktofile = "";
-                _stopWrite.Reset();
+                _stopWrite = false;
                 _writerStopped.Reset();
 
                 string previewImage = "";
@@ -3182,7 +3182,7 @@ namespace iSpyApplication.Controls
                             Helper.FrameAction? peakFrame = null;
                             bool first = true;
 
-                            while (!_stopWrite.WaitOne(0))
+                            while (!_stopWrite)
                             {
                                 Helper.FrameAction fa;
                                 if (Buffer.TryDequeue(out fa))
@@ -5386,7 +5386,7 @@ namespace iSpyApplication.Controls
         {
             if (Recording)
             {
-               _stopWrite.Set();
+                _stopWrite = true;
                 _writerStopped.WaitOne();
             }
         }

--- a/Controls/CameraWindow.cs
+++ b/Controls/CameraWindow.cs
@@ -3196,6 +3196,12 @@ namespace iSpyApplication.Controls
                                     WriteFrame(fa, recordingStart, ref lastvideopts, ref maxAlarm, ref peakFrame,
                                         ref lastaudiopts);
                                 }
+                                else
+                                {
+                                    // nothing to dequeue
+                                    // yield for now
+                                    Thread.Yield();
+                                }
                                 if (bAudio)
                                 {
                                     if (vc.Buffer.TryDequeue(out fa))

--- a/Sources/Video/MediaStream.cs
+++ b/Sources/Video/MediaStream.cs
@@ -137,7 +137,7 @@ namespace iSpyApplication.Sources.Video
         {
             var vss = Source;
             if (!_modeAudio)
-                vss = Tokenise();
+                vss = Tokenise(vss);
 
             AVDictionary* options = null;
             if (_inputFormat == null)
@@ -604,7 +604,6 @@ namespace iSpyApplication.Sources.Video
 
                 ffmpeg.av_free_packet(&packet);
                 ffmpeg.av_frame_free(&frame);
-                Thread.SpinWait(20);
             } while (!_abort && !MainForm.ShuttingDown);
 
 


### PR DESCRIPTION
MediaStream.cs:
- Frame reading blocks in ffmpeg and does not need the 20ms additional latency introduced by the spin lock.
- Fixed build break: Tokenise() requires an argument.
CameraWindow.cs:
- Interprocess system wide events are computationally heavy.  Reduce CPU utilization on every frame in the recording loop by using a simple boolean flag. According to the VS2017 profiler this saves about 5% of the CPU.