### PR TITLE
Fix high CPU usage when recording

### DIFF
--- a/Realtime/MediaWriter.cs
+++ b/Realtime/MediaWriter.cs
@@ -806,8 +806,6 @@ namespace iSpyApplication.Realtime
             }
 
             _videoCodecContext->pix_fmt = _avPixelFormat;
-            
-            //ffmpeg.av_opt_set(_videoCodecContext->priv_data, "tune", "zerolatency", 0);
 
             switch (_videoCodecContext->codec_id)
             {
@@ -823,8 +821,24 @@ namespace iSpyApplication.Realtime
                 case AVCodecID.AV_CODEC_ID_H264:
                     ffmpeg.av_opt_set(_videoCodecContext->priv_data, "profile", "main", 0);
                     ffmpeg.av_opt_set(_videoCodecContext->priv_data, "preset", "slow", 0);
-                    _videoCodecContext->qmin = 16;
-                    _videoCodecContext->qmax = 26;
+                    _videoCodecContext->coder_type = ffmpeg.FF_CODER_TYPE_AC;
+                    _videoCodecContext->flags |= ffmpeg.CODEC_FLAG_LOOP_FILTER;
+                    _videoCodecContext->scenechange_threshold = 40;
+                    _videoCodecContext->gop_size = 40;
+                    _videoCodecContext->max_b_frames = 0;
+                    _videoCodecContext->max_qdiff = 4;
+                    _videoCodecContext->me_method = 7;
+                    _videoCodecContext->me_range = 16;
+                    _videoCodecContext->me_cmp |= 1;
+                    _videoCodecContext->me_subpel_quality = 6;
+                    _videoCodecContext->qmin = 10;
+                    _videoCodecContext->qmax = 51;
+                    _videoCodecContext->qcompress = 0.6f;
+                    _videoCodecContext->keyint_min = 2;
+                    _videoCodecContext->trellis = 0;
+                    _videoCodecContext->level = 13;
+                    _videoCodecContext->refs = 1;
+                    ffmpeg.av_opt_set(_videoCodecContext->priv_data, "tune", "zerolatency", 0);
                     break;
                 case AVCodecID.AV_CODEC_ID_HEVC:
                     ffmpeg.av_opt_set(_videoCodecContext->priv_data, "x265-params", "qp=20", 0);


### PR DESCRIPTION
Using old encoding options (from version 6.5.8.0) for H264 reduces the
CPU load several times during recording
#26 