### PR TITLE
Fix Onvif Timestamp Error

### DIFF
--- a/Onvif/Security/DigestSecurityHeader.cs
+++ b/Onvif/Security/DigestSecurityHeader.cs
@@ -64,7 +64,7 @@ namespace iSpyApplication.Onvif.Security
         private DateTime GetCurrentServerTime()
         {
             long timestamp = Stopwatch.GetTimestamp();
-            long elapsedMilliseconds = timestamp - _createdTimestamp * 1000 / Stopwatch.Frequency;
+            long elapsedMilliseconds = (timestamp - _createdTimestamp) * 1000 / Stopwatch.Frequency;
 
             if (elapsedMilliseconds < 0)
             {


### PR DESCRIPTION
My Camera(XNP-6550RH) checks Onvif timestamp, but the bug has caused an calculate error.

![스크린샷 2020-03-11 오후 3 39 48](https://user-images.githubusercontent.com/9896724/76390062-09ead400-63b0-11ea-9174-953af601db05.png)

